### PR TITLE
🔒 Fix Path Traversal in DIYP API endpoint

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -4,8 +4,9 @@ monkey.patch_all()
 
 from apiflask import APIFlask, Schema
 from apiflask.fields import String, Date
-from flask import send_file
+from flask import send_file, send_from_directory
 from flask_compress import Compress
+from werkzeug.exceptions import NotFound
 import os
 
 
@@ -24,16 +25,11 @@ def diyp(query_data):
     ch = query_data["ch"]
     date = query_data["date"]
     try:
-        return send_file(
-            os.path.join(
-                os.getcwd(),
-                "web",
-                "diyp_files",
-                ch,
-                date.strftime("%Y-%m-%d") + ".json",
-            )
+        return send_from_directory(
+            directory=os.path.join(os.getcwd(), "web", "diyp_files"),
+            path=os.path.join(ch, date.strftime("%Y-%m-%d") + ".json"),
         )
-    except FileNotFoundError:
+    except (FileNotFoundError, NotFound):
         return send_file(os.path.join(os.getcwd(), "web", "404.json"))
 
 


### PR DESCRIPTION
The `/diyp` endpoint was vulnerable to path traversal because it used the unvalidated `ch` query parameter directly in `os.path.join`. An attacker could potentially use `..` to access files outside the `web/diyp_files` directory.

I have replaced this with `flask.send_from_directory`, which is specifically designed to handle path joining securely by preventing traversal. I also updated the exception handling to catch `werkzeug.exceptions.NotFound`, ensuring that the API continues to return the custom `404.json` file when a resource is missing or traversal is attempted.

Verified the fix logic with a script demonstrating that `..` and absolute paths are correctly blocked. Reverted unnecessary environment changes and cleaned up all temporary files.

---
*PR created automatically by Jules for task [9126591055278329012](https://jules.google.com/task/9126591055278329012) started by @riverscn*